### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
         os: [windows-latest]
-        python-version: ["3.8", "3.10", "3.11"] # 3.9 failed - do the others pass??
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload coverage
       if: ${{ matrix.os == 'ubuntu-latest' }} and {{ matrix.python-version == '3.8' }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         verbose: true # optional (default = false)
 
@@ -72,7 +72,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v3
       with:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -19,7 +19,9 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # NOTE: macOS-13 is the last Intel runner.
+        # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
+        os: [ubuntu-latest, macOS-13, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
         os: [macOS-13]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
-        os: [macOS-13]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         activate-environment: dev
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         activate-environment: dev

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
         os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11"] # 3.9 failed - do the others pass??
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest, macOS-13]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
-        os: [ubuntu-latest, macOS-13, windows-latest]
+        os: [macOS-13]
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # NOTE: macOS-13 is the last Intel runner.
         # When we move past that version we'll need to deal with Apple Silicon, likely using MUMPS.
-        os: [ubuntu-latest]
+        os: [windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/pymatsolver/iterative.py
+++ b/pymatsolver/iterative.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 import scipy.sparse as sp
 from scipy.sparse.linalg import aslinearoperator, bicgstab
 from packaging.version import Version

--- a/pymatsolver/iterative.py
+++ b/pymatsolver/iterative.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
-from scipy.sparse.linalg import bicgstab
+from scipy.sparse.linalg import aslinearoperator, bicgstab
 from pymatsolver.solvers import Base
 
 
@@ -23,7 +23,7 @@ class BicgJacobi(Base):
             return
         nSize = self.A.shape[0]
         Ainv = sp.spdiags(1./self.A.diagonal(), 0, nSize, nSize)
-        self.M = sp.linalg.interface.aslinearoperator(Ainv)
+        self.M = aslinearoperator(Ainv)
         self._factored = True
 
     def _solve1(self, rhs):

--- a/pymatsolver/iterative.py
+++ b/pymatsolver/iterative.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import aslinearoperator, bicgstab
-from packaging import Version
+from packaging.version import Version
 from pymatsolver.solvers import Base
 
 # The tol kwarg was removed from bicgstab in scipy 1.14.0.

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,5 +3,5 @@ numpydoc
 
 # Restrict pydata-sphinx-theme on older versions of Python on Windows.
 # Otherwise we get doc build failures.
-pydata-sphinx-theme~=0.14.4 ; python_version <= '3.9' and os_name == "Windows"
+pydata-sphinx-theme~=0.14.4,<0.15 ; python_version <= '3.9' and os_name == "Windows"
 pydata-sphinx-theme

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,5 +3,5 @@ numpydoc
 
 # Restrict pydata-sphinx-theme on older versions of Python on Windows.
 # Otherwise we get doc build failures.
-pydata-sphinx-theme~=0.14.4,<0.15 ; python_version <= '3.9' and os_name == "Windows"
+pydata-sphinx-theme~=0.14.4,<0.15 ; python_version <= '3.9' and platform_system == "Windows"
 pydata-sphinx-theme

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,7 @@
 sphinx
 numpydoc
+
+# Restrict pydata-sphinx-theme on older versions of Python on Windows.
+# Otherwise we get doc build failures.
+pydata-sphinx-theme~=0.14.4 ; python_version <= '3.9' and os_name == "Windows"
 pydata-sphinx-theme

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(exclude=["*mumps", "tests"]),
     install_requires=[
         'numpy>=1.7',
-        'scipy>=0.13',
+        'scipy>=1.8',
     ],
     author="Rowan Cockett",
     author_email="rowanc1@gmail.com",


### PR DESCRIPTION
This PR gets CI passing on all platforms.

* Action versions have been upgraded.
    *  `conda-incubator/setup-miniconda@v3`.  [Version 3.0.4](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.4) of that action addresses the issue that runners no longer provide miniconda by default.
    * `actions/checkout@v4`, `codecov/codecov-action@v4`.  Version 2 ran on node.js 12 which is no longer available in GitHub Actions.
* Python 3.7 is dropped and the minimum version of scipy is bumped to 1.8.  This matches SimPEG's supported versions.  I also added CI runs on Python 3.11, which pass nicely with no special modifications.
* MacOS runners are constrained to `macOS-13`.  The `macOS-latest` runner is now Apple Silicon, which means that the pardiso solver can no longer be used on those runners.  We'll want to get MUMPS working for macOS eventually; that effort is already in progress over in #43.
* `packaging` is added as a dependency so we can check which version of `scipy` is in use; this allows the `BicgJacobi` iterative solver to be compatible with versions of scipy that include the old `tol` and new `rtol` kwarg names.

Fixes #45.