### PR TITLE
Refactor base class

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -3,7 +3,7 @@ name: Testing
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - 'v*'
   pull_request:

--- a/pymatsolver/__init__.py
+++ b/pymatsolver/__init__.py
@@ -24,6 +24,7 @@ Triangular
 .. autosummary::
   :toctree: generated/
 
+  Triangle
   Forward
   Backward
 
@@ -60,7 +61,7 @@ AvailableSolvers = {
 }
 
 # Simple solvers
-from .solvers import Diagonal, Forward, Backward
+from .solvers import Diagonal, Triangle, Forward, Backward
 from .wrappers import WrapDirect
 from .wrappers import WrapIterative
 

--- a/pymatsolver/__init__.py
+++ b/pymatsolver/__init__.py
@@ -62,8 +62,8 @@ AvailableSolvers = {
 
 # Simple solvers
 from .solvers import Diagonal, Triangle, Forward, Backward
-from .wrappers import WrapDirect
-from .wrappers import WrapIterative
+from .wrappers import wrap_direct, WrapDirect
+from .wrappers import wrap_iterative, WrapIterative
 
 # Scipy Iterative solvers
 from .iterative import SolverCG

--- a/pymatsolver/direct/mumps.py
+++ b/pymatsolver/direct/mumps.py
@@ -39,7 +39,6 @@ class Mumps(Base):
         attrs['ordering'] = self.ordering
         return attrs
 
-    @property
     def transpose(self):
         trans_obj = Mumps.__new__(Mumps)
         trans_obj._A = self.A

--- a/pymatsolver/direct/mumps.py
+++ b/pymatsolver/direct/mumps.py
@@ -7,8 +7,8 @@ class Mumps(Base):
     """
     _transposed = False
 
-    def __init__(self, A, ordering=None, **kwargs):
-        super().__init__(A, **kwargs)
+    def __init__(self, A, ordering=None, is_symmetric=None, is_positive_definite=False, is_hermitian=None, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs):
+        super().__init__(A, is_symmetric=is_symmetric, is_positive_definite=is_positive_definite, is_hermitian=is_hermitian, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
         if ordering is None:
             ordering = "metis"
         self.ordering = ordering
@@ -19,7 +19,6 @@ class Mumps(Base):
         self.solver.set_matrix(
             A,
             symmetric=self.is_symmetric,
-            # positive_definite=self.is_positive_definite  # doesn't (yet) support setting positive definiteness
         )
 
     @property

--- a/pymatsolver/direct/mumps.py
+++ b/pymatsolver/direct/mumps.py
@@ -48,13 +48,14 @@ class Mumps(Base):
         return trans_obj
 
     def factor(self, A=None):
-        reuse_analysis = False
-        if A is not None:
+        reuse_analysis = self._factored
+        do_factor = not self._factored
+        if A is not None and A is not self.A:
+            # if it was previously factored then re-use the analysis.
             self._set_A(A)
             self._A = A
-            # if it was previously factored then re-use the analysis.
-            reuse_analysis = self._factored
-        if not self._factored:
+            do_factor = True
+        if do_factor:
             pivot_tol = 0.0 if self.is_positive_definite else 0.01
             self.solver.factor(
                 ordering=self.ordering, reuse_analysis=reuse_analysis, pivot_tol=pivot_tol

--- a/pymatsolver/direct/pardiso.py
+++ b/pymatsolver/direct/pardiso.py
@@ -16,13 +16,15 @@ class Pardiso(Base):
 
     _transposed = False
 
-    def __init__(self, A, **kwargs):
+    def __init__(self, A, n_threads=None, **kwargs):
         super().__init__(A, **kwargs)
         self.solver = MKLPardisoSolver(
             self.A,
             matrix_type=self._matrixType(),
             factor=False
         )
+        if n_threads is not None:
+            self.n_threads = n_threads
 
     def _matrixType(self):
         """

--- a/pymatsolver/direct/pardiso.py
+++ b/pymatsolver/direct/pardiso.py
@@ -16,8 +16,8 @@ class Pardiso(Base):
 
     _transposed = False
 
-    def __init__(self, A, n_threads=None, **kwargs):
-        super().__init__(A, **kwargs)
+    def __init__(self, A, n_threads=None, is_symmetric=None, is_positive_definite=False, is_hermitian=None, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs):
+        super().__init__(A, is_symmetric=is_symmetric, is_positive_definite=is_positive_definite, is_hermitian=is_hermitian, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
         self.solver = MKLPardisoSolver(
             self.A,
             matrix_type=self._matrixType(),

--- a/pymatsolver/iterative.py
+++ b/pymatsolver/iterative.py
@@ -20,8 +20,8 @@ class BiCGJacobi(Base):
     def __init__(self, A, symmetric=None, maxiter=1000, rtol=1E-6, atol=0.0, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs):
         if symmetric is not None:
             warnings.warn(
-                "The symmetric keyword argument is unused and is deprecated. It will be removed in pymatsolver 0.7.0.",
-                DeprecationWarning, stacklevel=2
+                "The symmetric keyword argument is unused and is deprecated. It will be removed in pymatsolver 0.4.0.",
+                FutureWarning, stacklevel=2
             )
         super().__init__(A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
         self._factored = False

--- a/pymatsolver/iterative.py
+++ b/pymatsolver/iterative.py
@@ -17,13 +17,13 @@ SolverBiCG = WrapIterative(bicgstab, name="SolverBiCG")
 class BiCGJacobi(Base):
     """Bicg Solver with Jacobi preconditioner"""
 
-    def __init__(self, A, symmetric=None, maxiter=1000, rtol=1E-6, atol=0.0, **kwargs):
+    def __init__(self, A, symmetric=None, maxiter=1000, rtol=1E-6, atol=0.0, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs):
         if symmetric is not None:
             warnings.warn(
-                "The symmetric keyword argument is being deprecated and will be removed in pymatsolver 0.7.0",
+                "The symmetric keyword argument is unused and is deprecated. It will be removed in pymatsolver 0.7.0.",
                 DeprecationWarning, stacklevel=2
             )
-        super().__init__(A, **kwargs)
+        super().__init__(A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
         self._factored = False
         self.maxiter = maxiter
         self.rtol = rtol

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -40,6 +40,9 @@ class Base(ABC):
         Extra keyword arguments. If there are any left here a warning will be raised.
     """
 
+    __numpy_ufunc__ = True
+    __array_ufunc__ = None
+
     def __init__(
             self, A, is_symmetric=None, is_positive_definite=False, is_hermitian=None, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs
     ):

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -218,6 +218,7 @@ class Base(ABC):
         if self.check_accuracy:
             self._compute_accuracy(rhs, x)
 
+        #TODO remove this in v0.4.0.
         if x.size == n:
             x = x.reshape(-1)
         return x

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -84,7 +84,11 @@ class Base(ABC):
         self.is_positive_definite = is_positive_definite
 
         if kwargs:
-            warnings.warn(f"Unused keyword arguments for {self.__class__.__name__}: {kwargs.keys()}")
+            warnings.warn(
+                f"Unused keyword arguments for {self.__class__.__name__}: {kwargs.keys()}",
+                UserWarning,
+                stacklevel=3
+            )
 
     @property
     def A(self):
@@ -323,7 +327,7 @@ class Base(ABC):
                 # then expand out the first dimension into multiple dimensions.
                 x = x.reshape(in_shape)
                 # then switch last two dimensions again.
-                x = x.swapaxes(x,  -1, -2)
+                x = x.swapaxes(-1, -2)
 
         if self.check_accuracy:
             self._compute_accuracy(rhs, x)

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -455,7 +455,7 @@ class Diagonal(Base):
         return rhs / self._diagonal[:, None]
 
 
-class TriangularSolver(Base):
+class Triangle(Base):
     """A solver for a diagonal matrix.
 
     Parameters
@@ -512,7 +512,7 @@ class TriangularSolver(Base):
         return trans
 
 
-class Forward(TriangularSolver):
+class Forward(Triangle):
     """A solver for a lower triangular matrix.
 
     Parameters
@@ -538,7 +538,7 @@ class Forward(TriangularSolver):
         super().__init__(A, lower=True, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
 
 
-class Backward(TriangularSolver):
+class Backward(Triangle):
     """A solver for ann upper triangular matrix.
 
     Parameters

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -1,17 +1,111 @@
 import numpy as np
 import warnings
+import scipy.sparse as sp
+from scipy.sparse.linalg import spsolve_triangular
+from scipy.linalg import issymmetric, ishermitian
+from abc import ABC, abstractmethod
+import copy
 
 
 class PymatsolverAccuracyError(Exception):
     pass
 
 
-class Base():
-    _accuracy_tol = 1e-6
-    _check_accuracy = False
+class Base(ABC):
 
-    def __init__(self, A):
-        self.A = A.tocsr()
+    def __init__(
+            self, A, is_symmetric=None, is_positive_definite=False, is_hermitian=None, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs
+    ):
+        # don't make any assumptions on what A is, let the individual solvers handle that
+        shape = A.shape
+        if len(shape) != 2:
+            raise ValueError("A must be 2-dimensional.")
+        if shape[0] != shape[1]:
+            raise ValueError("A is not a square matrix.")
+        self._A = A
+        self._dtype = np.dtype(A.dtype)
+
+        if accuracy_tol is not None:
+            warnings.warn("accuracy_tol is deprecated, use check_rtol and check_atol.", FutureWarning)
+            check_rtol = accuracy_tol
+
+        self.check_accuracy = check_accuracy
+        self.check_rtol = check_rtol
+        self.check_atol = check_atol
+
+        # do some symmetry checks that likely speed up the defualt solve operation
+        if is_symmetric is None:
+            if sp.issparse(A):
+                is_symmetric = (A.T != A).nnz == 0
+            else:
+                is_symmetric = issymmetric(A)
+        self.is_symmetric = is_symmetric
+        if is_hermitian is None:
+            if self.is_real:
+                is_hermitian = self.is_symmetric
+            else:
+                if sp.issparse(A):
+                    is_hermitian = (A.T.conjugate() != A).nnz == 0
+                else:
+                    is_hermitian = ishermitian(A)
+
+        self.is_hermitian = is_hermitian
+
+        # Can't check for positive definiteness until it is factored.
+        # This should be defaulted to False. If the user knows ahead of time that it is positive definite
+        # they should set this to be true.
+        self.is_positive_definite = is_positive_definite
+
+        if kwargs:
+            warnings.warn(f"Unused keyword arguments for {self.__class__.__name__}: {kwargs.keys()}")
+
+    @property
+    def A(self):
+        return self._A
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def is_real(self):
+        return np.issubdtype(self.A.dtype, np.floating)
+
+    @property
+    def is_symmetric(self):
+        return self._is_symmetric
+
+    @is_symmetric.setter
+    def is_symmetric(self, value):
+        if isinstance(value, bool):
+            self._is_symmetric = value
+        else:
+            raise TypeError("is_symmetric must be a boolean.")
+
+    @property
+    def is_hermitian(self):
+        if self.is_real and self.is_symmetric:
+            return True
+        else:
+            return self._is_hermitian
+
+    @is_hermitian.setter
+    def is_hermitian(self, value):
+        if isinstance(value, bool):
+            self._is_hermitian = value
+        else:
+            raise TypeError("is_hermitian must be a boolean.")
+
+    @property
+    def is_positive_definite(self):
+        return self._is_positive_definite
+
+    @is_positive_definite.setter
+    def is_positive_definite(self, value):
+        if isinstance(value, bool):
+            self._is_positive_definite = value
+        else:
+            raise TypeError("is_positive_definite must be a boolean.")
 
     @property
     def check_accuracy(self):
@@ -20,84 +114,122 @@ class Base():
 
     @check_accuracy.setter
     def check_accuracy(self, value):
-        # Do this to do a lazy cast to boolean
-        test = (value == True)
-        if not isinstance(test, bool):
-            raise TypeError("check_accuracy must be either True or False")
-        self._check_accuracy = test
+        if isinstance(value, bool):
+            self._check_accuracy = value
+        else:
+            raise TypeError("check_accuracy must be a boolean.")
 
     @property
-    def accuracy_tol(self):
+    def check_rtol(self):
         "tolerance on the accuracy of the solver"
-        return self._accuracy_tol
+        return self._check_rtol
 
-    @accuracy_tol.setter
-    def accuracy_tol(self, value):
-        try:
-            self._accuracy_tol = float(value)
-        except Exception:
-            raise TypeError("accuracy_tol must be a float value")
-
-    def set_kwargs(self, ignore=None,  **kwargs):
-        """
-            Sets key word arguments (kwargs) that are present in the object,
-            throw a warning if they don't exist.
-        """
-        if ignore is None:
-            ignore = []
-        for attr in kwargs:
-            if attr in ignore:
-                continue
-            if hasattr(self, attr):
-                setattr(self, attr, kwargs[attr])
-            else:
-                warnings.warn('{0!s} attr is not recognized and will be unused'.format(attr))
+    @check_rtol.setter
+    def check_rtol(self, value):
+        value = float(value)
+        if value > 0:
+            self._check_rtol = float(value)
+        else:
+            raise ValueError("check_rtol must be greater than zero.")
 
     @property
-    def _transposeClass(self):
+    def check_atol(self):
+        "tolerance on the accuracy of the solver"
+        return self._check_atol
+
+    @check_atol.setter
+    def check_atol(self, value):
+        value = float(value)
+        if value >= 0:
+            self._check_atol = float(value)
+        else:
+            raise ValueError("check_atol must be greater than or equal to zero.")
+
+    @property
+    def _transpose_class(self):
         return self.__class__
 
-    @property
-    def T(self):
-        "The transpose operator for this class"
-        if self._transposeClass is None:
+    def transpose(self):
+        "The transpose operator for this class."
+        if self.is_symmetric:
+            return self
+        if self._transpose_class is None:
             raise NotImplementedError(
                 'The transpose for the {} class is not possible.'.format(
                     self.__name__
                 )
             )
-        newS = self._transposeClass(self.A.T)
+        newS = self._transpose_class(self.A.T, **self.get_attributes())
         return newS
 
-    def _compute_accuracy(self, rhs, x):
-        nrm = np.linalg.norm(np.ravel(self.A*x - rhs), np.inf)
-        nrm_rhs = np.linalg.norm(np.ravel(rhs), np.inf)
-        if nrm_rhs > 0:
-            nrm /= nrm_rhs
-        if nrm > self.accuracy_tol:
-            msg = 'Accuracy on solve is above tolerance: {0:e} > {1:e}'.format(
-                nrm, self.accuracy_tol
-            )
-            raise PymatsolverAccuracyError(msg)
+    @property
+    def T(self):
+        return self.transpose()
 
-    def _solve(self, rhs):
+    def _compute_accuracy(self, rhs, x):
+        resid_norm = np.linalg.norm(rhs - self.A @ x)
+        rhs_norm = np.linalg.norm(rhs)
+        tolerance = max(self.check_rtol * rhs_norm, self.check_atol)
+        if resid_norm > tolerance:
+            raise PymatsolverAccuracyError(
+                f'Accuracy on solve is above tolerance: {resid_norm} > {tolerance}'
+            )
+
+    def solve(self, rhs):
+        # Make this broadcast just like numpy.linalg.solve!
 
         n = self.A.shape[0]
-        assert rhs.size % n == 0, 'Incorrect shape of rhs.'
-        nrhs = rhs.size // n
-
-        if len(rhs.shape) == 1 or rhs.shape[1] == 1:
-            x = self._solve1(rhs)
+        ndim = len(rhs.shape)
+        if ndim == 1:
+            if len(rhs) != n:
+                raise ValueError(f'Expected a vector of length {n}, got {len(rhs)}')
+            x = self._solve_single(rhs)
         else:
-            x = self._solveM(rhs)
+            if ndim == 2 and rhs.shape[-1] == 1:
+                warnings.warn(
+                    "In the pymatsolver v0.7.0 passing a vector of shape (n, 1) to the solve method "
+                    "will return an array with shape (n, 1), instead of always returning a flattened array. "
+                    "This is to be consistent with numpy.linalg.solve broadcasting.",
+                    FutureWarning
+                )
+            if rhs.shape[-2] != n:
+                raise ValueError(f'Second to last dimension should be {n}, got {rhs.shape}')
+            do_broadcast = rhs.ndim > 2
+            if do_broadcast:
+                # switch last two dimensions
+                rhs = np.transpose(rhs, (*range(rhs.ndim-2), -1, -2))
+                in_shape = rhs.shape
+                # Then collapse all other vectors into the last dimension
+                rhs = np.reshape(rhs, (-1, in_shape[-1]))
+                # Then reverse the two axes to get the array to end up in fortran order
+                # (which is more common for direct solvers).
+                rhs = np.transpose(rhs)
+                # should end up with shape (n, -1)
+            x = self._solve_multiple(rhs)
+            if do_broadcast:
+                # undo the reshaping above
+                # so first, reverse the axes again.
+                x = np.transpose(x)
+                # then expand out the first dimension into multiple dimensions.
+                x = np.reshape(x, in_shape)
+                # then switch last two dimensions again.
+                x = np.transpose(x, (*range(rhs.ndim-2), -1, -2))
 
         if self.check_accuracy:
             self._compute_accuracy(rhs, x)
 
-        if nrhs == 1:
-            return x.flatten()
-        elif nrhs > 1:
-            return x.reshape((n, nrhs), order='F')
+        if x.size == n:
+            x = x.reshape(-1)
+        return x
+
+    @abstractmethod
+    def _solve_single(self, rhs):
+        ...
+
+
+    def _solve_multiple(self, rhs):
+        ...
+
 
     def clean(self):
         pass
@@ -105,105 +237,106 @@ class Base():
     def __del__(self):
         """Destruct to call clean when object is garbage collected."""
         try:
+            # make sure clean is called in case the underlying solver
+            # doesn't automatically cleanup itself when garbage collected...
             self.clean()
         except:
             pass
 
     def __mul__(self, val):
-        if type(val) is np.ndarray:
-            return self._solve(val)
-        raise TypeError('Can only multiply by a numpy array.')
+        return self.solve(val)
 
-    @property
-    def is_real(self):
-        return self.A.dtype == float
+    def __matmul__(self, val):
+        return self.solve(val)
 
-    @property
-    def is_symmetric(self):
-        return getattr(self, '_is_symmetric', False)
-
-    @is_symmetric.setter
-    def is_symmetric(self, value):
-        self._is_symmetric = value
-
-    @property
-    def is_hermitian(self):
-        if self.is_real and self.is_symmetric:
-            return True
-        else:
-            return getattr(self, '_is_hermitian', False)
-
-    @is_hermitian.setter
-    def is_hermitian(self, value):
-        self._is_hermitian = value
-
-    @property
-    def is_positive_definite(self):
-        return getattr(self, '_is_positive_definite', False)
-
-    @is_positive_definite.setter
-    def is_positive_definite(self, value):
-        self._is_positive_definite = value
+    def get_attributes(self):
+        attrs = {
+            "is_symmetric": self.is_symmetric,
+            "is_hermitian": self.is_hermitian,
+            "is_positive_definite": self.is_positive_definite,
+            "check_accuracy": self.check_accuracy,
+            "check_rtol": self.check_rtol,
+            "check_atol": self.check_atol,
+        }
+        return attrs
 
 
 class Diagonal(Base):
 
-    _transposeClass = None
+    def __init__(self, A, **kwargs):
+        try:
+            self._diagonal = np.asarray(A.diagonal())
+            if not np.all(self._diagonal):
+                # this works because 0 evaluates as False!
+                raise ValueError("Diagonal matrix has a zero along the diagonal.")
+        except AttributeError:
+            raise TypeError("A must have a diagonal() method.")
+        kwargs.pop("is_symmetric", None)
+        kwargs.pop("is_hermitian", None)
+        is_positive_definite = kwargs.pop("is_positive_definite", None)
+        super().__init__(
+            A, is_symmetric=True, is_hermitian=True, **kwargs
+        )
+        if is_positive_definite is None:
+            if self.is_real:
+                is_positive_definite = self._diagonal.min() > 0
+            else:
+                is_positive_definite = (not np.any(self._diagonal.imag)) and self._diagonal.real.min() > 0
+            is_positive_definite = bool(is_positive_definite)
+        self.is_positive_definite = is_positive_definite
 
-    def __init__(self, A):
-        self.A = A
-        self._diagonal = A.diagonal()
+    def _solve_single(self, rhs):
+        return rhs / self._diagonal
 
-    def _solve1(self, rhs):
-        return rhs.flatten()/self._diagonal
-
-    def _solveM(self, rhs):
-        n = self.A.shape[0]
-        nrhs = rhs.size // n
-        return rhs/self._diagonal.repeat(nrhs).reshape((n, nrhs))
-
-
-class Forward(Base):
-
-    _transposeClass = None
-
-    def __init__(self, A):
-        self.A = A.tocsr()
-
-    def _solveM(self, rhs):
-
-        vals = self.A.data
-        rowptr = self.A.indptr
-        colind = self.A.indices
-        x = np.empty_like(rhs)
-        for i in range(self.A.shape[0]):
-            ith_row = vals[rowptr[i]:rowptr[i+1]]
-            cols = colind[rowptr[i]:rowptr[i+1]]
-            x_vals = x[cols]
-            x[i] = (rhs[i] - np.dot(ith_row[:-1], x_vals[:-1])) / ith_row[-1]
-        return x
-
-    _solve1 = _solveM
+    def _solve_multiple(self, rhs):
+        # broadcast the division
+        return rhs / self._diagonal[:, None]
 
 
-class Backward(Base):
+class TriangularSolver(Base):
+    def __init__(self, A, lower=True, **kwargs):
+        kwargs.pop("is_hermitian", False)
+        kwargs.pop("is_symmetric", False)
+        if not (sp.issparse(A) and A.format in ['csr','csc']):
+            A = sp.csc_matrix(A)
+        A.sum_duplicates()
+        super().__init__(A, is_hermitian=False, is_symmetric=False, **kwargs)
+        self.lower = lower
 
-    _transposeClass = None
+    @property
+    def lower(self):
+        return self._lower
 
-    def __init__(self, A):
-        self.A = A.tocsr()
+    @lower.setter
+    def lower(self, value):
+        if isinstance(value, bool):
+            self._lower = value
+        else:
+            raise TypeError("lower must be a bool.")
 
-    def _solveM(self, rhs):
+    def _solve_multiple(self, rhs):
+        return spsolve_triangular(self.A, rhs, lower=self.lower)
 
-        vals = self.A.data
-        rowptr = self.A.indptr
-        colind = self.A.indices
-        x = np.empty_like(rhs)
-        for i in reversed(range(self.A.shape[0])):
-            ith_row = vals[rowptr[i]:rowptr[i+1]]
-            cols = colind[rowptr[i]:rowptr[i+1]]
-            x_vals = x[cols]
-            x[i] = (rhs[i] - np.dot(ith_row[1:], x_vals[1:])) / ith_row[0]
-        return x
+    _solve_single = _solve_multiple
 
-    _solve1 = _solveM
+    def transpose(self):
+        transed = super().transpose()
+        transed.lower = not self.lower
+        return transed
+
+class Forward(TriangularSolver):
+
+    def __init__(self, A, **kwargs):
+        kwargs.pop("lower", None)
+        super().__init__(A, lower=True, **kwargs)
+
+class Backward(TriangularSolver):
+
+    _transpose_class = Forward
+
+    def __init__(self, A, **kwargs):
+        kwargs.pop("lower", None)
+        super().__init__(A, lower=False, **kwargs)
+
+
+Forward._transpose_class = Backward

--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -26,7 +26,7 @@ class Base(ABC):
         self._dtype = np.dtype(A.dtype)
 
         if accuracy_tol is not None:
-            warnings.warn("accuracy_tol is deprecated, use check_rtol and check_atol.", FutureWarning)
+            warnings.warn("accuracy_tol is deprecated and will be removed in v0.4.0, use check_rtol and check_atol.", FutureWarning, stacklevel=2)
             check_rtol = accuracy_tol
 
         self.check_accuracy = check_accuracy
@@ -324,11 +324,13 @@ class TriangularSolver(Base):
         trans.lower = not self.lower
         return trans
 
+
 class Forward(TriangularSolver):
 
     def __init__(self, A, check_accuracy=False, check_rtol=1e-6, check_atol=0, accuracy_tol=None, **kwargs):
         kwargs.pop("lower", None)
         super().__init__(A, lower=True, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol, **kwargs)
+
 
 class Backward(TriangularSolver):
 

--- a/pymatsolver/wrappers.py
+++ b/pymatsolver/wrappers.py
@@ -71,13 +71,11 @@ def WrapDirect(fun, factorize=True, name=None):
     >>> SolverLU = pymatsolver.WrapDirect(splu, factorize=True)
     """
 
-    def __init__(self, A, **kwargs):
-        pymatsolver_options = {}
-        if (check_accuracy := kwargs.pop('check_accuracy', None)) is not None:
-            pymatsolver_options['check_accuracy'] = check_accuracy
-        if (accuracy_tol := kwargs.pop('accuracy_tol', None)) is not None:
-            pymatsolver_options['accuracy_tol'] = accuracy_tol
-        Base.__init__(self, A, **pymatsolver_options)
+    def __init__(self, A, check_accuracy=False, check_rtol=1E-6, check_atol=0, accuracy_tol=None, **kwargs):
+        Base.__init__(
+            self, A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol,
+            is_symmetric=False, is_hermitian=False
+        )
         self.kwargs = kwargs
         if factorize:
             self.solver = fun(self.A, **self.kwargs)
@@ -127,7 +125,7 @@ def WrapDirect(fun, factorize=True, name=None):
     )
 
 
-def WrapIterative(fun, check_accuracy=False, accuracy_tol=1e-6, name=None):
+def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
     """
     Wraps an iterative Solver.
 
@@ -148,11 +146,16 @@ def WrapIterative(fun, check_accuracy=False, accuracy_tol=1e-6, name=None):
     >>> SolverCG = pymatsolver.WrapIterative(cg)
 
     """
+    if check_accuracy is not None or accuracy_tol is not None:
+        warnings.warn('check_accuracy and accuracy_tol were unused and are now deprecated. They '
+                      'will be removed in pymatsolver v0.4.0. Please pass the keyword arguments `check_rtol` '
+                      'and check_atol directly to the wrapped solver class.', FutureWarning)
 
-    def __init__(self, A, **kwargs):
-        check_acc = kwargs.pop('check_accuracy', check_accuracy)
-        acc_tol = kwargs.pop('accuracy_tol', accuracy_tol)
-        Base.__init__(self, A, check_accuracy=check_acc, accuracy_tol=acc_tol)
+    def __init__(self, A, check_accuracy=False, check_rtol=1E-6, check_atol=0, accuracy_tol=None, **kwargs):
+        Base.__init__(
+            self, A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol,
+            is_symmetric=False, is_hermitian=False
+        )
         self.kwargs = kwargs
 
     @property

--- a/pymatsolver/wrappers.py
+++ b/pymatsolver/wrappers.py
@@ -42,8 +42,8 @@ def WrapDirect(fun, factorize=True, name=None):
     fun : callable
         The solver function to be wrapped.
     factorize : bool
-        If `fun` returns a factorized object that has a ``solve()`` method. This allows
-        it to be re-used for repeated solve calls.
+        Set to ``True`` if `fun` will return a factorized object that has a ``solve()``
+        method. This allows it to be re-used for repeated solve calls.
     name : str, optional
         The name of the wrapped class to return.
 
@@ -74,7 +74,6 @@ def WrapDirect(fun, factorize=True, name=None):
     def __init__(self, A, check_accuracy=False, check_rtol=1E-6, check_atol=0, accuracy_tol=None, **kwargs):
         Base.__init__(
             self, A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol,
-            is_symmetric=False, is_hermitian=False
         )
         self.kwargs = kwargs
         if factorize:
@@ -154,7 +153,6 @@ def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
     def __init__(self, A, check_accuracy=False, check_rtol=1E-6, check_atol=0, accuracy_tol=None, **kwargs):
         Base.__init__(
             self, A, check_accuracy=check_accuracy, check_rtol=check_rtol, check_atol=check_atol, accuracy_tol=accuracy_tol,
-            is_symmetric=False, is_hermitian=False
         )
         self.kwargs = kwargs
 

--- a/pymatsolver/wrappers.py
+++ b/pymatsolver/wrappers.py
@@ -148,7 +148,7 @@ def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
     if check_accuracy is not None or accuracy_tol is not None:
         warnings.warn('check_accuracy and accuracy_tol were unused and are now deprecated. They '
                       'will be removed in pymatsolver v0.4.0. Please pass the keyword arguments `check_rtol` '
-                      'and check_atol directly to the wrapped solver class.', FutureWarning)
+                      'and check_atol directly to the wrapped solver class.', FutureWarning, stacklevel=2)
 
     def __init__(self, A, check_accuracy=False, check_rtol=1E-6, check_atol=0, accuracy_tol=None, **kwargs):
         Base.__init__(

--- a/pymatsolver/wrappers.py
+++ b/pymatsolver/wrappers.py
@@ -1,23 +1,91 @@
+import warnings
+from inspect import signature
 import numpy as np
-from scipy.sparse import linalg
+
 from pymatsolver.solvers import Base
+
+def _valid_kwargs_for_func(func, **kwargs):
+    """Validates keyword arguments for a function by inspecting its signature.
+
+    This will issue a warning if the function does not accept the keyword.
+
+    Returns
+    -------
+    valid_kwargs : dict
+        Arguments able to be passed to the function (based on its signature).
+
+    Notes
+    -----
+    If a function's signature accepts `**kwargs` then all keyword arguments are
+    valid by definition, even if the function might throw its own exceptions based
+    off of the arguments you pass. This function will not check for those keyword
+    arguments.
+    """
+    sig = signature(func)
+    valid_kwargs = {}
+    for key, value in kwargs.items():
+        try:
+            sig.bind_partial(**{key: value})
+            valid_kwargs[key] = value
+        except TypeError:
+            warnings.warn(f'Unused keyword argument "{key}" for {func.__name__}.', stacklevel=3)
+            # stack level of three because we want the warning issued at the call
+            # to the wrapped solver's `__init__` method.
+    return valid_kwargs
 
 
 def WrapDirect(fun, factorize=True, name=None):
     """Wraps a direct Solver.
 
-    ::
+    Parameters
+    ----------
+    fun : callable
+        The solver function to be wrapped.
+    factorize : bool
+        If `fun` returns a factorized object that has a ``solve()`` method. This allows
+        it to be re-used for repeated solve calls.
+    name : str, optional
+        The name of the wrapped class to return.
 
-        Solver   = pymatsolver.WrapDirect(sp.linalg.spsolve, factorize=False)
-        SolverLU = pymatsolver.WrapDirect(sp.linalg.splu, factorize=True)
+    Returns
+    -------
+    wrapped : pymatsolver.solvers.Base
 
+    Notes
+    -----
+    Keyword arguments passed to the returned object on initialization will be checked
+    against `fun`'s signature. If `factorize` is ``True``, then they will additionally be
+    checked against the factorized object's ``solve()`` method signature. These checks
+    will not cause errors, but will issue warnings saying they are unused.
+
+    Examples
+    --------
+    >>> import pymatsolver
+    >>> from scipy.sparse.linalg import spsolve, splu
+
+    Scipy's ``spsolve`` does not support reuse, so we must pass ``factorize=false``.
+    >>> Solver   = pymatsolver.WrapDirect(spsolve, factorize=False)
+
+    Scipy's ``splu`` returns an `SuperLU` object that has a `solve` method, and therefore
+    does support reuse, so we must pass ``factorize=true``.
+    >>> SolverLU = pymatsolver.WrapDirect(splu, factorize=True)
     """
 
     def __init__(self, A, **kwargs):
         self.A = A.tocsc()
         self.kwargs = kwargs
         if factorize:
-            self.solver = fun(self.A, **kwargs)
+            self.solver = fun(self.A, **self.kwargs)
+            if getattr(self.solver, "solve", None) is not None:
+                raise TypeError(f"instance returned by {fun.__name__} must have a solve() method.")
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+    @kwargs.setter
+    def kwargs(self, keyword_arguments):
+        self._kwargs = _valid_kwargs_for_func(fun, **keyword_arguments)
 
     def _solve1(self, rhs):
         rhs = rhs.flatten()
@@ -26,7 +94,7 @@ def WrapDirect(fun, factorize=True, name=None):
             rhs = rhs.astype(type(rhs[0]))
 
         if factorize:
-            X = self.solver.solve(rhs, **self.kwargs)
+            X = self.solver.solve(rhs)
         else:
             X = fun(self.A, rhs, **self.kwargs)
 
@@ -66,15 +134,35 @@ def WrapIterative(fun, check_accuracy=True, accuracyTol=1e-5, name=None):
     """
     Wraps an iterative Solver.
 
-    ::
+    Returns
+    -------
+    wrapped : pymatsolver.solvers.Base
 
-        SolverCG = pymatsolver.WrapIterative(sp.linalg.cg)
+    Notes
+    -----
+    Keyword arguments passed to the returned object on initialization will be checked
+    against `fun`'s signature.These checks will not cause errors, but will issue warnings
+    saying they are unused.
+
+    Examples
+    --------
+    >>> import pymatsolver
+    >>> from scipy.sparse.linalg import cg
+    >>> SolverCG = pymatsolver.WrapIterative(cg)
 
     """
 
     def __init__(self, A, **kwargs):
         self.A = A
         self.kwargs = kwargs
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+    @kwargs.setter
+    def kwargs(self, keyword_arguments):
+        self._kwargs = _valid_kwargs_for_func(fun, **keyword_arguments)
 
     def _solve1(self, rhs):
 

--- a/pymatsolver/wrappers.py
+++ b/pymatsolver/wrappers.py
@@ -28,13 +28,13 @@ def _valid_kwargs_for_func(func, **kwargs):
             sig.bind_partial(**{key: value})
             valid_kwargs[key] = value
         except TypeError:
-            warnings.warn(f'Unused keyword argument "{key}" for {func.__name__}.', stacklevel=3)
+            warnings.warn(f'Unused keyword argument "{key}" for {func.__name__}.', UserWarning, stacklevel=3)
             # stack level of three because we want the warning issued at the call
             # to the wrapped solver's `__init__` method.
     return valid_kwargs
 
 
-def WrapDirect(fun, factorize=True, name=None):
+def wrap_direct(fun, factorize=True, name=None):
     """Wraps a direct Solver.
 
     Parameters
@@ -121,6 +121,7 @@ def WrapDirect(fun, factorize=True, name=None):
             "__init__": __init__,
             "_solve_single": _solve_single,
             "_solve_multiple": _solve_multiple,
+            "kwargs": kwargs,
             "clean": clean,
         }
     )
@@ -146,7 +147,7 @@ def WrapDirect(fun, factorize=True, name=None):
     return WrappedClass
 
 
-def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
+def wrap_iterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
     """
     Wraps an iterative Solver.
 
@@ -229,6 +230,7 @@ def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
             "__init__": __init__,
             "_solve_single": _solve_single,
             "_solve_multiple": _solve_multiple,
+            "kwargs": kwargs,
         }
     )
     WrappedClass.__doc__ = f"""Wrapped {class_name} solver.
@@ -253,3 +255,6 @@ def WrapIterative(fun, check_accuracy=None, accuracy_tol=None, name=None):
 
     return WrappedClass
 
+
+WrapDirect = wrap_direct
+WrapIterative = wrap_iterative

--- a/tests/test_Basic.py
+++ b/tests/test_Basic.py
@@ -2,10 +2,10 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 import scipy.sparse as sp
+import pymatsolver
 from pymatsolver import Diagonal
 
 TOL = 1e-12
-
 
 def test_DiagonalSolver():
 
@@ -23,3 +23,67 @@ def test_DiagonalSolver():
 
     npt.assert_allclose(sol, X, atol=TOL)
     npt.assert_allclose(sol[:, 0], x, atol=TOL)
+
+class IdentitySolver(pymatsolver.solvers.Base):
+    """"A concrete implementation of Base, for testing purposes"""
+    def _solve_single(self, rhs):
+        return rhs
+
+    def _solve_multiple(self, rhs):
+        return rhs
+
+
+def test_basics():
+
+    Ainv = IdentitySolver(np.eye(4))
+    assert Ainv.is_symmetric == True
+    assert Ainv.is_hermitian == True
+    assert Ainv.shape == (4, 4)
+
+    Ainv = IdentitySolver(np.eye(4) + 0j)
+    assert Ainv.is_symmetric == True
+    assert Ainv.is_hermitian == True
+
+def test_basic_solve():
+    Ainv = IdentitySolver(np.eye(4))
+
+    rhs = np.arange(4)
+    rhs2d = np.arange(8).reshape(4, 2)
+    rhs3d = np.arange(16).reshape(2, 4, 2)
+
+    npt.assert_equal(Ainv @ rhs, rhs)
+    npt.assert_equal(Ainv @ rhs2d, rhs2d)
+    npt.assert_equal(Ainv @ rhs3d, rhs3d)
+
+
+# use Diagonal solver as a concrete instance of the Base to test for some errors
+
+def test_errors_and_warnings():
+
+    # from Base...
+    with pytest.raises(ValueError, match="A must be 2-dimensional."):
+        IdentitySolver(np.full((3, 3, 3), 1))
+
+    with pytest.raises(ValueError, match="A is not a square matrix."):
+        IdentitySolver(np.full((3, 5), 1))
+
+    with pytest.warns(FutureWarning, match="accuracy_tol is deprecated.*"):
+        IdentitySolver(np.full((4, 4), 1), accuracy_tol=0.41)
+
+    with pytest.warns(UserWarning, match="Unused keyword arguments.*"):
+        IdentitySolver(np.full((4, 4), 1), not_an_argument=4)
+
+    with pytest.raises(TypeError, match="is_symmetric must be a boolean."):
+        IdentitySolver(np.full((4, 4), 1), is_symmetric="True")
+
+    with pytest.raises(TypeError, match="is_hermitian must be a boolean."):
+        IdentitySolver(np.full((4, 4), 1), is_hermitian="True")
+
+    with pytest.raises(TypeError, match="is_positive_definite must be a boolean."):
+        IdentitySolver(np.full((4, 4), 1), is_positive_definite="True")
+
+    with pytest.raises(ValueError, match="check_rtol must.*"):
+        IdentitySolver(np.full((4, 4), 1), check_rtol=0.0)
+
+    with pytest.raises(ValueError, match="check_atol must.*"):
+        IdentitySolver(np.full((4, 4), 1), check_atol=-1.0)

--- a/tests/test_Basic.py
+++ b/tests/test_Basic.py
@@ -55,6 +55,9 @@ def test_basic_solve():
     npt.assert_equal(Ainv @ rhs2d, rhs2d)
     npt.assert_equal(Ainv @ rhs3d, rhs3d)
 
+    npt.assert_equal(rhs @ Ainv, rhs)
+    npt.assert_equal(rhs.T * Ainv, rhs)
+
 
 # use Diagonal solver as a concrete instance of the Base to test for some errors
 
@@ -87,3 +90,15 @@ def test_errors_and_warnings():
 
     with pytest.raises(ValueError, match="check_atol must.*"):
         IdentitySolver(np.full((4, 4), 1), check_atol=-1.0)
+
+    with pytest.raises(ValueError, match="Expected a vector of length.*"):
+        Ainv = IdentitySolver(np.eye(4, 4))
+        Ainv @ np.ones(3)
+
+    with pytest.raises(ValueError, match="Second to last dimension should be.*"):
+        Ainv = IdentitySolver(np.eye(4, 4))
+        Ainv @ np.ones((3, 2))
+
+    with pytest.warns(FutureWarning, match="In Future pymatsolver v0.4.0, passing a vector.*"):
+        Ainv = IdentitySolver(np.eye(4, 4))
+        Ainv @ np.ones((4, 1))

--- a/tests/test_Basic.py
+++ b/tests/test_Basic.py
@@ -18,7 +18,7 @@ def test_DiagonalSolver():
 
     with pytest.raises(TypeError):
         Diagonal(A, check_accuracy=np.array([1, 2, 3]))
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         Diagonal(A, accuracy_tol=0)
 
     npt.assert_allclose(sol, X, atol=TOL)

--- a/tests/test_Basic.py
+++ b/tests/test_Basic.py
@@ -15,6 +15,10 @@ class IdentitySolver(pymatsolver.solvers.Base):
     def _solve_multiple(self, rhs):
         return rhs
 
+    def clean(self):
+        # this is to test that the __del__ still executes if the object doesn't successfully clean.
+        raise MemoryError("Nothing to cleanup!")
+
 class NotTransposableIdentitySolver(IdentitySolver):
     """ A class that can't be transposed."""
 

--- a/tests/test_BicgJacobi.py
+++ b/tests/test_BicgJacobi.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import scipy.sparse as sp
 import pytest
 
-TOL = 1e-5
+RTOL = 1e-5
 
 @pytest.fixture()
 def test_mat_data():
@@ -15,28 +15,30 @@ def test_mat_data():
     A = A.tocsr()
     np.random.seed(1)
     sol = np.random.rand(nSize, 4)
-    rhs = A.dot(sol)
-    return A, sol, rhs
+    return A, sol
 
 
 @pytest.mark.parametrize('transpose', [True, False])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-def test_solve(test_mat_data, dtype, transpose):
-    A, rhs, sol = test_mat_data
+@pytest.mark.parametrize('symmetric', [True, False])
+def test_solve(test_mat_data, dtype, transpose, symmetric):
+    A, sol = test_mat_data
     A = A.astype(dtype)
-    rhs = rhs.astype(dtype)
     sol = sol.astype(dtype)
+    if not symmetric:
+        D = sp.diags(np.linspace(2, 3, A.shape[0]))
+        A = D @ A
+    rhs = A @ sol
     if transpose:
-        A = A.T
-        Ainv = BicgJacobi(A).T
+        Ainv = BicgJacobi(A.T, is_symmetric=symmetric).T
     else:
-        Ainv = BicgJacobi(A)
+        Ainv = BicgJacobi(A, is_symmetric=symmetric)
     Ainv.maxiter = 2000
     solb = Ainv * rhs
-    npt.assert_allclose(rhs, A @ solb, atol=TOL)
+    npt.assert_allclose(rhs, A @ solb, rtol=RTOL)
 
 def test_errors_and_warnings(test_mat_data):
-    A, rhs, sol = test_mat_data
+    A, sol = test_mat_data
     with pytest.warns(FutureWarning):
         Ainv = BicgJacobi(A, symmetric=True)
 
@@ -47,7 +49,7 @@ def test_errors_and_warnings(test_mat_data):
         Ainv = BicgJacobi(A, atol=-1.0)
 
 def test_shallow_copy(test_mat_data):
-    A, rhs, sol = test_mat_data
+    A, sol = test_mat_data
     Ainv = BicgJacobi(A, maxiter=100, rtol=1.0E-3, atol=1.0E-16)
 
     attrs = Ainv.get_attributes()

--- a/tests/test_BicgJacobi.py
+++ b/tests/test_BicgJacobi.py
@@ -28,9 +28,9 @@ def test_solve(test_mat_data, dtype, transpose):
     sol = sol.astype(dtype)
     if transpose:
         A = A.T
-        Ainv = BicgJacobi(A, symmetric=True).T
+        Ainv = BicgJacobi(A).T
     else:
-        Ainv = BicgJacobi(A, symmetric=True)
+        Ainv = BicgJacobi(A)
     Ainv.maxiter = 2000
     solb = Ainv * rhs
     npt.assert_allclose(rhs, A @ solb, atol=TOL)

--- a/tests/test_BicgJacobi.py
+++ b/tests/test_BicgJacobi.py
@@ -34,3 +34,23 @@ def test_solve(test_mat_data, dtype, transpose):
     Ainv.maxiter = 2000
     solb = Ainv * rhs
     npt.assert_allclose(rhs, A @ solb, atol=TOL)
+
+def test_errors_and_warnings(test_mat_data):
+    A, rhs, sol = test_mat_data
+    with pytest.warns(FutureWarning):
+        Ainv = BicgJacobi(A, symmetric=True)
+
+    with pytest.raises(ValueError):
+        Ainv = BicgJacobi(A, rtol=0.0)
+
+    with pytest.raises(ValueError):
+        Ainv = BicgJacobi(A, atol=-1.0)
+
+def test_shallow_copy(test_mat_data):
+    A, rhs, sol = test_mat_data
+    Ainv = BicgJacobi(A, maxiter=100, rtol=1.0E-3, atol=1.0E-16)
+
+    attrs = Ainv.get_attributes()
+
+    new_Ainv = BicgJacobi(A, **attrs)
+    assert attrs == new_Ainv.get_attributes()

--- a/tests/test_Mumps.py
+++ b/tests/test_Mumps.py
@@ -27,7 +27,8 @@ def test_mat_data():
 
 @pytest.mark.parametrize('transpose', [True, False])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
-def test_solve(test_mat_data, dtype, transpose):
+@pytest.mark.parametrize('symmetric', [True, False])
+def test_solve(test_mat_data, dtype, transpose, symmetric):
     A, rhs, sol = test_mat_data
     sol = sol.astype(dtype)
     rhs = rhs.astype(dtype)
@@ -45,17 +46,3 @@ def test_solve(test_mat_data, dtype, transpose):
 #     A = sp.identity(5).tocsr()
 #     A[-1, -1] = 0
 #     self.assertRaises(Exception, pymatsolver.Mumps, A)
-
-def test_multiFactorsInMem():
-    n = 100
-    A = sp.rand(n, n, 0.7)+sp.identity(n)
-    x = np.ones((n, 10))
-    rhs = A * x
-    solvers = [pymatsolver.Mumps(A) for _ in range(20)]
-
-    for Ainv in solvers:
-        npt.assert_allclose(Ainv * rhs, x, rtol=TOL)
-        Ainv.clean()
-
-    for Ainv in solvers:
-        npt.assert_allclose(Ainv * rhs, x, rtol=TOL)

--- a/tests/test_Mumps.py
+++ b/tests/test_Mumps.py
@@ -11,38 +11,46 @@ TOL = 1e-11
 
 @pytest.fixture()
 def test_mat_data():
-    n = 5
-    irn = np.r_[0, 1, 3, 4, 1, 0, 4, 2, 1, 2, 0, 2]
-    jcn = np.r_[1, 2, 2, 4, 0, 0, 1, 3, 4, 1, 2, 2]
-    a = np.r_[
-        3.0, -3.0, 2.0, 1.0, 3.0, 2.0,
-        4.0, 2.0, 6.0, -1.0, 4.0, 1.0
-    ]
-    rhs = np.r_[20.0, 24.0, 9.0, 6.0, 13.0]
-    rhs = np.c_[rhs, 10 * rhs, 100 * rhs]
-    sol = np.r_[1., 2., 3., 4., 5.]
-    sol = np.c_[sol, 10 * sol, 100 * sol]
-    A = sp.coo_matrix((a, (irn, jcn)), shape=(n, n))
-    return A, rhs, sol
+    nSize = 100
+    A = sp.rand(nSize, nSize, 0.05, format='csr', random_state=100)
+    A = A + sp.spdiags(np.ones(nSize), 0, nSize, nSize)
+    A = A.T*A
+    A = A.tocsr()
+    sol = np.linspace(0.9, 1.1, nSize)
+    sol = np.repeat(sol[:, None], 5, axis=-1)
+    return A, sol
+
 
 @pytest.mark.parametrize('transpose', [True, False])
 @pytest.mark.parametrize('dtype', [np.float64, np.complex128])
 @pytest.mark.parametrize('symmetric', [True, False])
 def test_solve(test_mat_data, dtype, transpose, symmetric):
-    A, rhs, sol = test_mat_data
+    A, sol = test_mat_data
     sol = sol.astype(dtype)
-    rhs = rhs.astype(dtype)
     A = A.astype(dtype)
+    if not symmetric:
+        D = sp.diags(np.linspace(2, 3, A.shape[0]))
+        A = D @ A
+    rhs = A @ sol
     if transpose:
-        Ainv = pymatsolver.Mumps(A.T).T
+        Ainv = pymatsolver.Mumps(A.T, is_symmetric=symmetric).T
     else:
-        Ainv = pymatsolver.Mumps(A)
-    for i in range(3):
+        Ainv = pymatsolver.Mumps(A, is_symmetric=symmetric)
+    for i in range(rhs.shape[1]):
         npt.assert_allclose(Ainv * rhs[:, i], sol[:, i], atol=TOL)
     npt.assert_allclose(Ainv * rhs, sol, atol=TOL)
 
 
-# def test_singular(self):
-#     A = sp.identity(5).tocsr()
-#     A[-1, -1] = 0
-#     self.assertRaises(Exception, pymatsolver.Mumps, A)
+def test_refactor(test_mat_data):
+    A, sol = test_mat_data
+    rhs = A @ sol
+    Ainv = pymatsolver.Mumps(A, is_symmetric=True)
+    npt.assert_allclose(Ainv * rhs, sol, atol=TOL)
+
+    # scale rows and columns
+    D = sp.diags(np.random.rand(A.shape[0]) + 1.0)
+    A2 = D.T @ A @ D
+
+    rhs2 = A2 @ sol
+    Ainv.factor(A2)
+    npt.assert_allclose(Ainv * rhs2, sol, atol=TOL)

--- a/tests/test_Pardiso.py
+++ b/tests/test_Pardiso.py
@@ -8,7 +8,7 @@ import os
 if not pymatsolver.AvailableSolvers['Pardiso']:
     pytest.skip(reason="Pardiso solver is not installed", allow_module_level=True)
 else:
-    from pydiso.mkl_solver import PardisoTypeConversionWarning, get_mkl_pardiso_max_threads
+    from pydiso.mkl_solver import get_mkl_pardiso_max_threads
 
 TOL = 1e-10
 

--- a/tests/test_Triangle.py
+++ b/tests/test_Triangle.py
@@ -21,3 +21,19 @@ def test_solve(solver):
     Ainv = solver(A)
     npt.assert_allclose(Ainv * rhs, sol, atol=TOL)
     npt.assert_allclose(Ainv * rhs[:, 0], sol[:, 0], atol=TOL)
+
+
+def test_triangle_errors():
+    A = sp.eye(5, format='csc')
+
+    with pytest.raises(TypeError, match="lower must be a bool."):
+        Ainv = pymatsolver.Forward(A)
+        Ainv.lower = 1
+
+
+def test_mat_convert():
+    Ainv = pymatsolver.Forward(sp.eye(5, format='coo'))
+    x = np.arange(5)
+    npt.assert_allclose(Ainv @ x, x)
+
+

--- a/tests/test_Triangle.py
+++ b/tests/test_Triangle.py
@@ -6,19 +6,27 @@ import pytest
 
 TOL = 1e-12
 
-@pytest.mark.parametrize("solver", [pymatsolver.Forward, pymatsolver.Backward])
-def test_solve(solver):
+@pytest.mark.parametrize("solver", [pymatsolver.Triangle, pymatsolver.Forward, pymatsolver.Backward])
+@pytest.mark.parametrize("transpose", [True, False])
+def test_solve(solver, transpose):
     n = 50
     nrhs = 20
     A = sp.rand(n, n, 0.4) + sp.identity(n)
     sol = np.ones((n, nrhs))
     if solver is pymatsolver.Backward:
         A = sp.triu(A)
+        lower = False
     else:
         A = sp.tril(A)
-    rhs = A @ sol
+        lower = True
 
-    Ainv = solver(A)
+    if transpose:
+        rhs = A.T @ sol
+        Ainv = solver(A, lower=lower).T
+    else:
+        rhs = A @ sol
+        Ainv = solver(A, lower=lower)
+
     npt.assert_allclose(Ainv * rhs, sol, atol=TOL)
     npt.assert_allclose(Ainv * rhs[:, 0], sol[:, 0], atol=TOL)
 

--- a/tests/test_Wrappers.py
+++ b/tests/test_Wrappers.py
@@ -1,0 +1,24 @@
+from pymatsolver import SolverCG, SolverLU
+import pytest
+import scipy.sparse as sp
+import warnings
+
+
+@pytest.mark.parametrize("solver_class", [SolverCG, SolverLU])
+def test_wrapper_unused_kwargs(solver_class):
+    A = sp.eye(10)
+
+    with pytest.warns(UserWarning, match="Unused keyword argument.*"):
+        solver_class(A, not_a_keyword_arg=True)
+
+def test_good_arg_iterative():
+    # Ensure this doesn't throw a warning!
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        SolverCG(sp.eye(10), rtol=1e-4)
+
+def test_good_arg_direct():
+    # Ensure this doesn't throw a warning!
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        SolverLU(sp.eye(10, format='csc'), permc_spec='NATURAL')

--- a/tests/test_Wrappers.py
+++ b/tests/test_Wrappers.py
@@ -2,6 +2,8 @@ from pymatsolver import SolverCG, SolverLU, wrap_direct, wrap_iterative
 import pytest
 import scipy.sparse as sp
 import warnings
+import numpy.testing as npt
+import numpy as np
 
 
 @pytest.mark.parametrize("solver_class", [SolverCG, SolverLU])
@@ -69,3 +71,12 @@ def test_iterative_deprecations():
 
     with pytest.warns(FutureWarning, match="check_accuracy and accuracy_tol were unused.*"):
         wrap_iterative(iterative_solver, accuracy_tol=1E-3)
+
+def test_non_scipy_iterative():
+    def iterative_solver(A, x):
+        return x
+
+    Wrapped = wrap_iterative(iterative_solver)
+
+    Ainv = Wrapped(sp.eye(4))
+    npt.assert_equal(Ainv @ np.arange(4), np.arange(4))

--- a/tests/test_Wrappers.py
+++ b/tests/test_Wrappers.py
@@ -1,4 +1,4 @@
-from pymatsolver import SolverCG, SolverLU
+from pymatsolver import SolverCG, SolverLU, wrap_direct, wrap_iterative
 import pytest
 import scipy.sparse as sp
 import warnings
@@ -22,3 +22,50 @@ def test_good_arg_direct():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         SolverLU(sp.eye(10, format='csc'), permc_spec='NATURAL')
+
+
+def test_bad_direct_function():
+    def bad_direct_func(A):
+        class Empty():
+            def __init__(self, A):
+                self.A = A
+        # this object returned by the function doesn't have a solve method:
+        return Empty(A)
+    WrappedClass = wrap_direct(bad_direct_func, factorize=True)
+
+    with pytest.raises(TypeError, match="instance returned by.*"):
+        WrappedClass(sp.eye(2))
+
+
+
+def test_direct_clean_function():
+    def direct_func(A):
+        class Empty():
+            def __init__(self, A):
+                self.A = A
+
+            def solve(self, x):
+                return x
+
+            def clean(self):
+                self.A = None
+
+        return Empty(A)
+    WrappedClass = wrap_direct(direct_func, factorize=True)
+
+    A = sp.eye(2)
+    Ainv = WrappedClass(A)
+    assert Ainv.A is A
+    assert Ainv.solver.A is A
+    Ainv.clean()
+    assert Ainv.solver.A is None
+
+def test_iterative_deprecations():
+    def iterative_solver(A, x):
+        return x
+
+    with pytest.warns(FutureWarning, match="check_accuracy and accuracy_tol were unused.*"):
+        wrap_iterative(iterative_solver, check_accuracy=True)
+
+    with pytest.warns(FutureWarning, match="check_accuracy and accuracy_tol were unused.*"):
+        wrap_iterative(iterative_solver, accuracy_tol=1E-3)


### PR DESCRIPTION
This refactor is aimed at increasing consistency throughout the package, adding a few bits of missing information.

* Gets rid of the ugly `set_kwargs` funciton.
* Automatically do a check for symmetry and hermitian, if not given.
* Exposes a solve() operation that broadcast's like `np.linalg.solve`.
* Uses Scipy's triangular solver for `Forward` and `Backward` class (and makes them transposes of each other).
* Check's wrapped function signatures for valid keyword arguments.
    * Emits warnings on unused keyword arguments.
* add a `solver.transpose()` method, which is aliased as a property as `solver.T`. 
* Define's `Base` as an abstract class, where subclasses must implement a `_solver_single` and a `_solve_multiple`.
* Mimic's scipy's more recent `rtol` and `atol` keywords for solution checking.
* Add `__matmul__`, `__rmatmul__`, and `__rmul__` operations.