### PR TITLE
Accepts Linear Operator as a valid input for solvers

### DIFF
--- a/pymatsolver/solvers.py
+++ b/pymatsolver/solvers.py
@@ -77,8 +77,10 @@ class Base(ABC):
         if is_symmetric is None:
             if sp.issparse(A):
                 is_symmetric = (A.T != A).nnz == 0
-            else:
+            elif isinstance(A, np.ndarray):
                 is_symmetric = issymmetric(A)
+            else:
+                is_symmetric = False
         self.is_symmetric = is_symmetric
         if is_hermitian is None:
             if self.is_real:
@@ -86,8 +88,10 @@ class Base(ABC):
             else:
                 if sp.issparse(A):
                     is_hermitian = (A.T.conjugate() != A).nnz == 0
-                else:
+                elif isinstance(A, np.ndarray):
                     is_hermitian = ishermitian(A)
+                else:
+                    is_hermitian = False
 
         self.is_hermitian = is_hermitian
 

--- a/tests/test_Scipy.py
+++ b/tests/test_Scipy.py
@@ -58,9 +58,10 @@ def test_solver(a_matrix, n_rhs, solver):
 
     npt.assert_allclose(x, b, atol=tol)
 
-def test_iterative_solver_linear_op():
+@pytest.mark.parametrize('dtype', [np.float64, np.complex128])
+def test_iterative_solver_linear_op(dtype):
     n = 10
-    A = aslinearoperator(sp.eye(n))
+    A = aslinearoperator(sp.eye(n).astype(dtype))
 
     Ainv = SolverCG(A)
 

--- a/tests/test_Scipy.py
+++ b/tests/test_Scipy.py
@@ -1,5 +1,6 @@
 from pymatsolver import Solver, Diagonal, SolverCG, SolverLU
 import scipy.sparse as sp
+from scipy.sparse.linalg import aslinearoperator
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -56,6 +57,16 @@ def test_solver(a_matrix, n_rhs, solver):
     Ainv.clean()
 
     npt.assert_allclose(x, b, atol=tol)
+
+def test_iterative_solver_linear_op():
+    n = 10
+    A = aslinearoperator(sp.eye(n))
+
+    Ainv = SolverCG(A)
+
+    rhs = np.linspace(0.9, 1.1, n)
+
+    npt.assert_allclose(Ainv @ rhs, rhs)
 
 @pytest.mark.parametrize('n_rhs', [1, 5])
 def test_diag_solver(n_rhs):

--- a/tests/test_Wrappers.py
+++ b/tests/test_Wrappers.py
@@ -14,11 +14,13 @@ def test_wrapper_unused_kwargs(solver_class):
     with pytest.warns(UnusedArgumentWarning, match="Unused keyword argument.*"):
         solver_class(A, not_a_keyword_arg=True)
 
+
 def test_good_arg_iterative():
     # Ensure this doesn't throw a warning!
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         SolverCG(sp.eye(10), rtol=1e-4)
+
 
 def test_good_arg_direct():
     # Ensure this doesn't throw a warning!
@@ -38,7 +40,6 @@ def test_bad_direct_function():
 
     with pytest.raises(TypeError, match="instance returned by.*"):
         WrappedClass(sp.eye(2))
-
 
 
 def test_direct_clean_function():
@@ -67,6 +68,7 @@ def test_direct_clean_function():
     Ainv.clean()
     assert Ainv.solver.A is None
 
+
 def test_iterative_deprecations():
 
     with pytest.warns(FutureWarning, match="check_accuracy and accuracy_tol were unused.*"):
@@ -74,6 +76,7 @@ def test_iterative_deprecations():
 
     with pytest.warns(FutureWarning, match="check_accuracy and accuracy_tol were unused.*"):
         wrap_iterative(lambda a, x: x, accuracy_tol=1E-3)
+
 
 def test_non_scipy_iterative():
     def iterative_solver(A, x):


### PR DESCRIPTION
Only will use scipy's `ishermitian` and `issymmetric` functions if the input matrix `A` is an `ndarray` now, allowing passing a wider range of input types for the matrix to solve, specifically this allows LinearOperator to be valid input (for the solvers it would be valid for, e.g. SolverCG).